### PR TITLE
Add shebang

### DIFF
--- a/odl.py
+++ b/odl.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 (c) 2021-2023 Yogesh Khatri, @SwiftForensics 
 


### PR DESCRIPTION
Add a shebang at the beginning of the script.

I use Cygwin, and am used to running Python scripts directly.

This change should benefit users of Cygwin, Windows Subsystem for Linux, and maybe even OneDrive on MacOS.

