### PR TITLE
Update odl.py to handle empty log files

### DIFF
--- a/odl.py
+++ b/odl.py
@@ -105,6 +105,10 @@ Odl_header = Struct(
     "reserved" / Byte[0x64]
 )
 
+def is_file_empty(file_path):
+    '''Check if file is empty by confirming if its size is 0 bytes'''
+    return os.path.exists(file_path) and os.stat(file_path).st_size == 0
+
 def read_string(data):
     '''read string, return tuple (bytes_consumed, string)'''
     if (len(data)) >= 4:
@@ -480,19 +484,22 @@ are not displayed. This can be toggled with the -d option.
         paths.extend(glob.glob(os.path.join(odl_folder, pattern)))
     for path in paths:
         print("Searching ", path)
-        try:
-            odl_rows = process_odl(path, map, args.all_data)
+        if is_file_empty(path):
+            print("File is empty, file size is 0 bytes")
+        else:
             try:
-                if odl_rows:
-                    writer.writerows(odl_rows)
-                    print(f'Wrote {len(odl_rows)} rows')
-                else:
-                    print("No log data was found in this file.")
-            except Exception as ex:
-                print("ERROR writing rows:", type(ex), ex)
-        except OSError as ex:
-            print(f"Error - File not found! {path}")
-        
+                odl_rows = process_odl(path, map, args.all_data)
+                try:
+                    if odl_rows:
+                        writer.writerows(odl_rows)
+                        print(f'Wrote {len(odl_rows)} rows')
+                    else:
+                        print("No log data was found in this file.")
+                except Exception as ex:
+                    print("ERROR writing rows:", type(ex), ex)
+            except OSError as ex:
+                print(f"Error - File not found! {path}")
+
     csv_f.close()
     print(f'Finished processing files, output is at {csv_file_path}')
 


### PR DESCRIPTION
This PR checks the globbed log file paths and skips log file processing if the file size is 0 bytes, to avoid an error like:

```
Traceback (most recent call last):
  File "/mnt/c/temp/odl.py", line 500, in <module>
    main()
  File "/mnt/c/temp/odl.py", line 484, in main
    odl_rows = process_odl(path, map, args.all_data)
  File "/mnt/c/temp/odl.py", line 304, in process_odl
    odl_header = Odl_header.parse(file_header)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 404, in parse
    return self.parse_stream(io.BytesIO(data), **contextkw)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 416, in parse_stream
    return self._parsereport(stream, context, "(parsing)")
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 428, in _parsereport
    obj = self._parse(stream, context, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 2236, in _parse
    subobj = sc._parsereport(stream, context, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 428, in _parsereport
    obj = self._parse(stream, context, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 2770, in _parse
    return self.subcon._parsereport(stream, context, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 428, in _parsereport
    obj = self._parse(stream, context, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 964, in _parse
    return stream_read(stream, length, path)
  File "/home/stephen/miniconda3/lib/python3.10/site-packages/construct/core.py", line 178, in stream_read
    raise StreamError("stream read less than specified amount, expected %d, found %d" % (length, len(data)), path=path)
construct.core.StreamError: Error in path (parsing) -> signature
stream read less than specified amount, expected 8, found 0
```